### PR TITLE
ShouldSerializeIsExternal() return value

### DIFF
--- a/Xbim.BCF/XMLNodes/BCFDocumentReference.cs
+++ b/Xbim.BCF/XMLNodes/BCFDocumentReference.cs
@@ -21,7 +21,7 @@ namespace Xbim.BCF.XMLNodes
         public bool IsExternal { get; set; }
         public bool ShouldSerializeIsExternal()
         {
-            return IsExternal = true;
+            return IsExternal;
         }
         /// <summary>
         /// URI to document. IsExternal=false "..\exampleDoc.docx" (within bcfzip) IsExternal=true "https://.../ exampleDoc.docx"


### PR DESCRIPTION
ShouldSerializeIsExternal() should return IsExternal value. We only serialize IsExternal if it's equal to true.